### PR TITLE
Bump pluggy-sdk to 0.85.2 and use built-in transaction fetch methods

### DIFF
--- a/examples/vercel-quickdeploy-nextjs/package-lock.json
+++ b/examples/vercel-quickdeploy-nextjs/package-lock.json
@@ -16,7 +16,7 @@
         "framer-motion": "12.23.24",
         "jsonwebtoken": "9.0.2",
         "next": "16.0.7",
-        "pluggy-sdk": "0.79.0",
+        "pluggy-sdk": "0.85.2",
         "react": "19.2.1",
         "react-dom": "19.2.1",
         "react-pluggy-connect": "2.11.0",
@@ -7260,13 +7260,13 @@
       }
     },
     "node_modules/pluggy-sdk": {
-      "version": "0.79.0",
-      "resolved": "https://registry.npmjs.org/pluggy-sdk/-/pluggy-sdk-0.79.0.tgz",
-      "integrity": "sha512-gNjkrks1HOXoBNhkJ1RuK1efk0ZDdcKHIadLEYbBv5QFdc1BP1pb2iSGq9nB8ebCDQgIQsZjVrMHhi+HOX84fQ==",
+      "version": "0.85.2",
+      "resolved": "https://registry.npmjs.org/pluggy-sdk/-/pluggy-sdk-0.85.2.tgz",
+      "integrity": "sha512-DWL/zyo1Ujg4vKuqrgDptpNBjyn/hQAudDubJRQRrJCJ7tUYEXXwrHYCJyCokl0+XTpebCg3v7/veNO1HYya+w==",
       "license": "MIT",
       "dependencies": {
         "got": "11.8.6",
-        "jsonwebtoken": "^9.0.2"
+        "jsonwebtoken": "9.0.2"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/examples/vercel-quickdeploy-nextjs/package.json
+++ b/examples/vercel-quickdeploy-nextjs/package.json
@@ -18,7 +18,7 @@
     "framer-motion": "12.23.24",
     "jsonwebtoken": "9.0.2",
     "next": "16.0.7",
-    "pluggy-sdk": "0.79.0",
+    "pluggy-sdk": "0.85.2",
     "react": "19.2.1",
     "react-dom": "19.2.1",
     "react-pluggy-connect": "2.11.0",

--- a/examples/vercel-quickdeploy-nextjs/src/app/lib/services/webhook-handlers/transactions-handler.ts
+++ b/examples/vercel-quickdeploy-nextjs/src/app/lib/services/webhook-handlers/transactions-handler.ts
@@ -16,33 +16,6 @@ import type {
 
 const pluggyClient = getPluggyClient();
 
-// Helper function to fetch all transactions with pagination
-async function fetchAllTransactionsWithFilter(
-  accountId: string, 
-  filters: { createdAtFrom?: string; ids?: string[] }
-): Promise<Transaction[]> {
-  const allTransactions: Transaction[] = [];
-  let page = 1;
-  let hasMore = true;
-
-  while (hasMore) {
-    const response = await pluggyClient.fetchTransactions(accountId, {
-      ...filters,
-      page,
-      pageSize: 500
-    });
-
-    if (response.results && response.results.length > 0) {
-      allTransactions.push(...response.results);
-    }
-
-    hasMore = response.results.length === 500;
-    page++;
-  }
-
-  return allTransactions;
-}
-
 export async function handleTransactionsCreated({ accountId, itemId, transactionsCreatedAtFrom }: Extract<WebhookEventPayload, { event: 'transactions/created' }>): Promise<void> {
   try {
     const accountExists = await accountsService.getAccountById(accountId);
@@ -51,7 +24,7 @@ export async function handleTransactionsCreated({ accountId, itemId, transaction
       await syncAccountData(itemId);
     }
 
-    const transactions = await fetchAllTransactionsWithFilter(accountId, {
+    const transactions = await pluggyClient.fetchAllTransactions(accountId, {
       createdAtFrom: transactionsCreatedAtFrom
     });
 
@@ -79,9 +52,18 @@ export async function handleTransactionsUpdated({transactionIds = [], accountId 
   try {
     if (transactionIds.length === 0) return;
 
-    const transactions = await fetchAllTransactionsWithFilter(accountId, {
-      ids: transactionIds
-    });
+    const transactions: Transaction[] = [];
+    let page = 1;
+    while (true) {
+      const response = await pluggyClient.fetchTransactions(accountId, {
+        ids: transactionIds,
+        page,
+        pageSize: 500,
+      });
+      transactions.push(...response.results);
+      if (response.results.length < 500) break;
+      page++;
+    }
 
     if (transactions.length === 0) return;
 


### PR DESCRIPTION
## Summary

Bumps `pluggy-sdk` from `0.79.0` to `0.85.2` (latest) in `examples/vercel-quickdeploy-nextjs` and refactors `transactions-handler.ts` to use the SDK's built-in fetch methods instead of a custom pagination helper.

Replaces / supersedes the intent of #23, which targeted 0.82.1.

## Changes

- `pluggy-sdk` 0.79.0 → 0.85.2 (exact pin)
- `handleTransactionsCreated` now uses `pluggyClient.fetchAllTransactions(accountId, { createdAtFrom })` — cursor-based, auto-paginated by the SDK
- `handleTransactionsUpdated` uses `pluggyClient.fetchTransactions(accountId, { ids, page, pageSize: 500 })` with a small pagination loop
- Removed the custom `fetchAllTransactionsWithFilter` helper (~25 lines)

## Note on the SDK API change

Between 0.82.1 and 0.85.2 the SDK migrated `fetchAllTransactions` to cursor-based pagination and dropped the `ids` filter from it. The `ids` filter is still available on `fetchTransactions` (paginated, page/pageSize), which is what the `transactions/updated` webhook handler now uses.

If a unified `fetchAllTransactions({ ids })` API is desired, that would be a follow-up feature request on [pluggy-sdk-nodejs](https://github.com/pluggyai/pluggy-sdk-node).

## Test plan
- [ ] `npm ci` in `examples/vercel-quickdeploy-nextjs` succeeds with new lock
- [ ] `npx tsc --noEmit` passes (verified locally ✓)
- [ ] Manually trigger `transactions/created` webhook — verify upserts
- [ ] Manually trigger `transactions/updated` webhook with > 0 and many ids — verify upserts