### PR TITLE
Bump pluggy-sdk 0.7.0 -> 0.7.1 in vercel-node-mongo

### DIFF
--- a/examples/vercel-node-mongo/package-lock.json
+++ b/examples/vercel-node-mongo/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "mongodb": "3.6.6",
         "pg": "8.6.0",
-        "pluggy-sdk": "0.7.0"
+        "pluggy-sdk": "0.7.1"
       },
       "devDependencies": {
         "@types/mongodb": "3.6.12",
@@ -47,62 +47,10 @@
         "typescript": "3.9.3"
       }
     },
-    "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/arg": {
       "version": "4.1.3",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/asn1": {
-      "version": "0.2.4",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "license": "MIT"
-    },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/aws4": {
-      "version": "1.11.0",
-      "license": "MIT"
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
     },
     "node_modules/bl": {
       "version": "2.2.1",
@@ -155,40 +103,9 @@
         "node": ">=4"
       }
     },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "license": "Apache-2.0"
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "license": "MIT"
-    },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/denque": {
       "version": "1.5.0",
@@ -207,138 +124,13 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "license": "MIT",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "license": "MIT"
-    },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT"
-    },
-    "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "license": "MIT"
-    },
-    "node_modules/fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "license": "MIT"
-    },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "2.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 0.12"
-      }
-    },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      }
-    },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "license": "ISC",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.5",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "license": "ISC"
     },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "license": "MIT"
-    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "license": "MIT"
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "license": "MIT"
-    },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "license": "MIT"
-    },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "license": "MIT"
-    },
-    "node_modules/json-stringify-safe": {
-      "version": "5.0.1",
-      "license": "ISC"
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
     },
     "node_modules/make-error": {
       "version": "1.3.6",
@@ -349,23 +141,6 @@
       "version": "1.5.0",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/mime-db": {
-      "version": "1.47.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.30",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.47.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/mongodb": {
       "version": "3.6.6",
@@ -424,13 +199,6 @@
         }
       }
     },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/optional-require": {
       "version": "1.0.3",
       "license": "Apache-2.0",
@@ -440,10 +208,6 @@
     },
     "node_modules/packet-reader": {
       "version": "1.0.0",
-      "license": "MIT"
-    },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
       "license": "MIT"
     },
     "node_modules/pg": {
@@ -514,11 +278,12 @@
       }
     },
     "node_modules/pluggy-sdk": {
-      "version": "0.7.0",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/pluggy-sdk/-/pluggy-sdk-0.7.1.tgz",
+      "integrity": "sha512-KJknns8WblfM0lK9j+4BZbj5GsOhy+5O1D8udz1IwIh/IBoZUxrUk5p+MuHQB08KnJ/PCxTlRYBSnSYXZ8GTVA==",
       "license": "MIT",
       "dependencies": {
-        "node-fetch": "^2.6.1",
-        "request": "^2.88.2"
+        "node-fetch": "^2.6.1"
       }
     },
     "node_modules/postgres-array": {
@@ -556,26 +321,6 @@
       "version": "2.0.1",
       "license": "MIT"
     },
-    "node_modules/psl": {
-      "version": "1.8.0",
-      "license": "MIT"
-    },
-    "node_modules/punycode": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.5.tgz",
-      "integrity": "sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.6"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "3.6.0",
       "license": "MIT",
@@ -583,35 +328,6 @@
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
       },
       "engines": {
         "node": ">= 6"
@@ -633,10 +349,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
       "license": "MIT"
     },
     "node_modules/saslprep": {
@@ -682,40 +394,11 @@
         "readable-stream": "^3.0.0"
       }
     },
-    "node_modules/sshpk": {
-      "version": "1.16.1",
-      "license": "MIT",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/tr46": {
@@ -748,20 +431,6 @@
         "typescript": ">=2.7"
       }
     },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "license": "Unlicense"
-    },
     "node_modules/typescript": {
       "version": "3.9.3",
       "dev": true,
@@ -774,35 +443,9 @@
         "node": ">=4.2.0"
       }
     },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "license": "MIT"
-    },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "license": "MIT",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -865,44 +508,9 @@
         "typescript": "3.9.3"
       }
     },
-    "ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
-      "requires": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      }
-    },
     "arg": {
       "version": "4.1.3",
       "dev": true
-    },
-    "asn1": {
-      "version": "0.2.4",
-      "requires": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "assert-plus": {
-      "version": "1.0.0"
-    },
-    "asynckit": {
-      "version": "0.4.0"
-    },
-    "aws-sign2": {
-      "version": "0.7.0"
-    },
-    "aws4": {
-      "version": "1.11.0"
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "requires": {
-        "tweetnacl": "^0.14.3"
-      }
     },
     "bl": {
       "version": "2.2.1",
@@ -944,26 +552,8 @@
     "buffer-writer": {
       "version": "2.0.0"
     },
-    "caseless": {
-      "version": "0.12.0"
-    },
-    "combined-stream": {
-      "version": "1.0.8",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
     "core-util-is": {
       "version": "1.0.2"
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
-    "delayed-stream": {
-      "version": "1.0.0"
     },
     "denque": {
       "version": "1.5.0"
@@ -974,96 +564,11 @@
       "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "dev": true
     },
-    "ecc-jsbn": {
-      "version": "0.1.2",
-      "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
-    "extend": {
-      "version": "3.0.2"
-    },
-    "extsprintf": {
-      "version": "1.3.0"
-    },
-    "fast-deep-equal": {
-      "version": "3.1.3"
-    },
-    "fast-json-stable-stringify": {
-      "version": "2.1.0"
-    },
-    "forever-agent": {
-      "version": "0.6.1"
-    },
-    "form-data": {
-      "version": "2.3.3",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      }
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
-    },
-    "har-schema": {
-      "version": "2.0.0"
-    },
-    "har-validator": {
-      "version": "5.1.5",
-      "requires": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
-      }
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      }
-    },
     "inherits": {
       "version": "2.0.4"
     },
-    "is-typedarray": {
-      "version": "1.0.0"
-    },
     "isarray": {
       "version": "1.0.0"
-    },
-    "isstream": {
-      "version": "0.1.2"
-    },
-    "jsbn": {
-      "version": "0.1.1"
-    },
-    "json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
-    },
-    "json-schema-traverse": {
-      "version": "0.4.1"
-    },
-    "json-stringify-safe": {
-      "version": "5.0.1"
-    },
-    "jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      }
     },
     "make-error": {
       "version": "1.3.6",
@@ -1072,15 +577,6 @@
     "memory-pager": {
       "version": "1.5.0",
       "optional": true
-    },
-    "mime-db": {
-      "version": "1.47.0"
-    },
-    "mime-types": {
-      "version": "2.1.30",
-      "requires": {
-        "mime-db": "1.47.0"
-      }
     },
     "mongodb": {
       "version": "3.6.6",
@@ -1101,17 +597,11 @@
         "whatwg-url": "^5.0.0"
       }
     },
-    "oauth-sign": {
-      "version": "0.9.0"
-    },
     "optional-require": {
       "version": "1.0.3"
     },
     "packet-reader": {
       "version": "1.0.0"
-    },
-    "performance-now": {
-      "version": "2.1.0"
     },
     "pg": {
       "version": "8.6.0",
@@ -1155,10 +645,11 @@
       }
     },
     "pluggy-sdk": {
-      "version": "0.7.0",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/pluggy-sdk/-/pluggy-sdk-0.7.1.tgz",
+      "integrity": "sha512-KJknns8WblfM0lK9j+4BZbj5GsOhy+5O1D8udz1IwIh/IBoZUxrUk5p+MuHQB08KnJ/PCxTlRYBSnSYXZ8GTVA==",
       "requires": {
-        "node-fetch": "^2.6.1",
-        "request": "^2.88.2"
+        "node-fetch": "^2.6.1"
       }
     },
     "postgres-array": {
@@ -1179,17 +670,6 @@
     "process-nextick-args": {
       "version": "2.0.1"
     },
-    "psl": {
-      "version": "1.8.0"
-    },
-    "punycode": {
-      "version": "2.1.1"
-    },
-    "qs": {
-      "version": "6.5.5",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.5.tgz",
-      "integrity": "sha512-mzR4sElr1bfCaPJe7m8ilJ6ZXdDaGoObcYR0ZHSsktM/Lt21MVHj5De30GQH2eiZ1qGRTO7LCAzQsUeXTNexWQ=="
-    },
     "readable-stream": {
       "version": "3.6.0",
       "requires": {
@@ -1198,36 +678,8 @@
         "util-deprecate": "^1.0.1"
       }
     },
-    "request": {
-      "version": "2.88.2",
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      }
-    },
     "safe-buffer": {
       "version": "5.2.1"
-    },
-    "safer-buffer": {
-      "version": "2.1.2"
     },
     "saslprep": {
       "version": "1.0.3",
@@ -1261,31 +713,10 @@
         "readable-stream": "^3.0.0"
       }
     },
-    "sshpk": {
-      "version": "1.16.1",
-      "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      }
-    },
     "string_decoder": {
       "version": "1.3.0",
       "requires": {
         "safe-buffer": "~5.2.0"
-      }
-    },
-    "tough-cookie": {
-      "version": "2.5.0",
-      "requires": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
       }
     },
     "tr46": {
@@ -1304,38 +735,12 @@
         "yn": "3.1.1"
       }
     },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5"
-    },
     "typescript": {
       "version": "3.9.3",
       "dev": true
     },
-    "uri-js": {
-      "version": "4.4.1",
-      "requires": {
-        "punycode": "^2.1.0"
-      }
-    },
     "util-deprecate": {
       "version": "1.0.2"
-    },
-    "uuid": {
-      "version": "3.4.0"
-    },
-    "verror": {
-      "version": "1.10.0",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      }
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/examples/vercel-node-mongo/package.json
+++ b/examples/vercel-node-mongo/package.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "mongodb": "3.6.6",
     "pg": "8.6.0",
-    "pluggy-sdk": "0.7.0"
+    "pluggy-sdk": "0.7.1"
   },
   "devDependencies": {
     "@types/mongodb": "3.6.12",


### PR DESCRIPTION
## Summary

Patch bump of `pluggy-sdk` in `examples/vercel-node-mongo` to clear both critical advisories.

## Before
- 6 vulnerabilities (2 critical, 4 moderate)
  - **Critical**: `form-data` uses unsafe random function for boundary
  - **Critical**: Server-Side Request Forgery in `request`
  - 4 transitive moderate advisories

## After
- 1 vulnerability (1 moderate)
  - Remaining: `mongodb` 3.6.6 may publish events containing auth data — needs a major bump, handled in a separate PR.

## Change

```diff
- "pluggy-sdk": "0.7.0"
+ "pluggy-sdk": "0.7.1"
```

Same-patch bump — no API surface change. Lock file simplified (~605 lines removed).

## Test plan
- [ ] `npm ci` succeeds in `examples/vercel-node-mongo`
- [ ] `npm audit` reports 0 criticals (verified locally ✓)
- [ ] The example endpoints still work at runtime