### PR TITLE
Fix: remove min-release-age from .npmrc files (Vercel build failure)

### DIFF
--- a/examples/aws-sst/.npmrc
+++ b/examples/aws-sst/.npmrc
@@ -1,2 +1,1 @@
 save-exact=true
-min-release-age=7d

--- a/examples/node-nestjs/.npmrc
+++ b/examples/node-nestjs/.npmrc
@@ -1,2 +1,1 @@
 save-exact=true
-min-release-age=7d

--- a/examples/vercel-node-connect-token/.npmrc
+++ b/examples/vercel-node-connect-token/.npmrc
@@ -1,2 +1,1 @@
 save-exact=true
-min-release-age=7d

--- a/examples/vercel-node-mongo/.npmrc
+++ b/examples/vercel-node-mongo/.npmrc
@@ -1,2 +1,1 @@
 save-exact=true
-min-release-age=7d

--- a/examples/vercel-quickdeploy-nextjs/.npmrc
+++ b/examples/vercel-quickdeploy-nextjs/.npmrc
@@ -1,2 +1,1 @@
 save-exact=true
-min-release-age=7d

--- a/frontend/cordova/.npmrc
+++ b/frontend/cordova/.npmrc
@@ -1,2 +1,1 @@
 save-exact=true
-min-release-age=7d

--- a/frontend/nextjs/.npmrc
+++ b/frontend/nextjs/.npmrc
@@ -1,2 +1,1 @@
 save-exact=true
-min-release-age=7d

--- a/frontend/react-native-expo/.npmrc
+++ b/frontend/react-native-expo/.npmrc
@@ -1,2 +1,1 @@
 save-exact=true
-min-release-age=7d

--- a/frontend/react-native/.npmrc
+++ b/frontend/react-native/.npmrc
@@ -1,2 +1,1 @@
 save-exact=true
-min-release-age=7d

--- a/frontend/react/.npmrc
+++ b/frontend/react/.npmrc
@@ -1,2 +1,1 @@
 save-exact=true
-min-release-age=7d


### PR DESCRIPTION
## Summary

Vercel's bundled npm crashes during `npm ci` when it reads `min-release-age=7d` from our `.npmrc` files:

```
npm warn invalid config before=null set in /vercel/path0/.npmrc
npm warn invalid config Must be one of: null, valid Date string
npm error Invalid time value
Error: Command "npm ci" exited with 1
```

Vercel's npm version is treating `min-release-age` as an alias for the deprecated `before` config, then failing to parse `"7d"` as a Date.

This blocks **all production deploys of `examples/vercel-quickdeploy-nextjs`** and any downstream forks (e.g. the workshop project that surfaced this).

## Why the line isn't load-bearing

Locally on npm 11.7 the same key emits:
```
npm warn Unknown project config "min-release-age". This will stop working in the next major version of npm.
```

So even where it doesn't crash, no current npm version is actually enforcing the intended 7-day supply-chain delay — the setting was effectively a no-op locally and a fatal error on Vercel.

## Change

Drop `min-release-age=7d` from all 10 `.npmrc` files. Keep `save-exact=true` everywhere — that's the load-bearing pin enforcement and is well-supported.

```diff
  save-exact=true
- min-release-age=7d
```

## Follow-up suggestion (not in this PR)

If 7-day-fresh-package quarantine is desired, reintroduce it via a supported mechanism — e.g. a CI guardrail like [`npm-audit-resolver`](https://www.npmjs.com/package/npm-audit-resolver), [Socket.dev](https://socket.dev), or a custom check in CI — rather than an `.npmrc` key that no current npm version honours and that Vercel rejects.

## Test plan
- [x] `npm ci` succeeds locally in `examples/vercel-quickdeploy-nextjs` without the warning
- [ ] Vercel deploy of `vercel-quickdeploy-nextjs` succeeds after merge
- [ ] Other npm-based projects still install with exact pins (verified via lock files; `save-exact` retained)