### PR TITLE
Bring vercel-node-connect-token pnpm setup up to repo standard

### DIFF
--- a/examples/vercel-node-connect-token/.gitignore
+++ b/examples/vercel-node-connect-token/.gitignore
@@ -1,3 +1,7 @@
 node_modules
 .vercel
 .env
+
+# Block npm/yarn lockfiles — this project is pnpm-only
+package-lock.json
+yarn.lock

--- a/examples/vercel-node-connect-token/.npmrc
+++ b/examples/vercel-node-connect-token/.npmrc
@@ -1,7 +1,0 @@
-save-exact=true
-registry=https://registry.npmjs.org/
-engine-strict=true
-audit-level=moderate
-update-notifier=false
-fund=false
-

--- a/examples/vercel-node-connect-token/package.json
+++ b/examples/vercel-node-connect-token/package.json
@@ -1,14 +1,26 @@
 {
   "name": "vercel-node-connect-token",
   "description": "A vercel serverless function example that creates a connect token to pair new accounts",
-  "engines": {
-    "node": ">=22.11.0"
-  },
   "packageManager": "pnpm@11.1.1",
-  "devDependencies": {
-    "@vercel/node": "1.10.0"
+  "engines": {
+    "node": ">=24.0.0",
+    "pnpm": ">=11.0.0"
+  },
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": ">=24.0.0",
+      "onFail": "error"
+    }
+  },
+  "scripts": {
+    "preinstall": "pnpm audit && pnpm audit signatures",
+    "lint:lockfile": "pnpm install --frozen-lockfile"
   },
   "dependencies": {
     "pluggy-sdk": "0.7.1"
+  },
+  "devDependencies": {
+    "@vercel/node": "1.10.0"
   }
 }

--- a/examples/vercel-node-connect-token/pnpm-lock.yaml
+++ b/examples/vercel-node-connect-token/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
 
 packages:
 
-  '@types/node@25.7.0':
-    resolution: {integrity: sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==}
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
   '@vercel/node@1.10.0':
     resolution: {integrity: sha512-11FIFoF4v9m/jAOSamwBDMsS2yIDa0fSnVhR70bbcUdBcu3BGGMCpg+jpA6rvkQSOa/WbTRvvu9hFh5bOsZxrw==}
@@ -71,8 +71,8 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
 
-  undici-types@7.21.0:
-    resolution: {integrity: sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==}
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -86,13 +86,13 @@ packages:
 
 snapshots:
 
-  '@types/node@25.7.0':
+  '@types/node@25.6.0':
     dependencies:
-      undici-types: 7.21.0
+      undici-types: 7.19.2
 
   '@vercel/node@1.10.0':
     dependencies:
-      '@types/node': 25.7.0
+      '@types/node': 25.6.0
       ts-node: 8.9.1(typescript@3.9.3)
       typescript: 3.9.3
 
@@ -134,7 +134,7 @@ snapshots:
 
   typescript@3.9.3: {}
 
-  undici-types@7.21.0: {}
+  undici-types@7.19.2: {}
 
   webidl-conversions@3.0.1: {}
 

--- a/examples/vercel-node-connect-token/pnpm-workspace.yaml
+++ b/examples/vercel-node-connect-token/pnpm-workspace.yaml
@@ -1,3 +1,70 @@
-minimumReleaseAge: 10080
-autoInstallPeers: true
+# Supply-chain hardening
+# ----------------------
 
+# Reject any package version published less than 14 days ago when
+# resolving. Existing locked versions install regardless (the filter
+# only kicks in on `pnpm install` / `pnpm update` when the lockfile
+# changes). Most supply-chain attacks are detected within hours or
+# days; the 14-day window absorbs that while keeping upgrades moving
+# at a reasonable pace. For a critical CVE that demands a sub-14d
+# upgrade, add a temporary `minimumReleaseAgeExclude` entry with a
+# CVE link and remove it once the window closes.
+# 14 days = 60 * 24 * 14 minutes
+minimumReleaseAge: 20160
+
+# When the registry metadata is missing the `time` field for a
+# version, fall back to allowing it.
+minimumReleaseAgeIgnoreMissingTime: true
+
+# Whitelist for the 14-day wait. `@pluggyai/*` ships from our own
+# release pipeline, so the window adds friction without adding
+# safety — third-party packages still go through the full wait.
+#
+# Ad-hoc third-party entries are only for documented CVE bypasses
+# (a fix released in the last 14 days that you can't wait for).
+# Each ad-hoc entry MUST include an inline comment of the form:
+#   # Remove after YYYY-MM-DD — <CVE / fix reference>
+# where the date is when the 14-day window closes on the fixed
+# version (release date + 14 days).
+minimumReleaseAgeExclude:
+  - '@pluggyai/*'
+
+# With exact pins in `package.json` there is only one version that
+# satisfies each dep, so this is effectively a no-op today. Pinned
+# explicitly to survive any future default change.
+resolutionMode: highest
+
+# Refuse to install if Node / pnpm don't satisfy the `engines` field
+# in `package.json`.
+engineStrict: true
+
+# Fail the install if a package version's trust level (signature,
+# provenance) drops compared to earlier versions of the same package.
+trustPolicy: no-downgrade
+
+# Auto-skip the trust check for packages older than this (90 days).
+trustPolicyIgnoreAfter: 129600
+
+# Block transitive dependencies from being resolved from exotic
+# sources (git URLs, direct tarballs, etc.).
+blockExoticSubdeps: true
+
+
+# Version pinning
+# ---------------
+
+# Save exact resolved versions (no semver ranges) on `pnpm add`.
+savePrefix: ""
+
+
+# Per-package decisions
+# ---------------------
+
+# pnpm 11 blocks postinstall / install / preinstall scripts by
+# default; every package that ships one must be listed here.
+# Default-deny: new entries start as `false` and only flip to `true`
+# after a conscious review.
+allowBuilds: {}
+
+# Force a specific version on transitive dependencies.
+overrides: {}


### PR DESCRIPTION
## Summary

Fix-up of #36. Brings \`examples/vercel-node-connect-token\` in line with the same pnpm 11 supply-chain hardening landed by the quickdeploy fix-up (#39).

## Changes

**\`package.json\`**
- \`engines.node\` \`>=22.11.0\` → \`>=24.0.0\`
- \`engines.pnpm: >=11.0.0\`
- \`devEngines.runtime\` with \`onFail: error\`
- \`scripts.preinstall: pnpm audit && pnpm audit signatures\`
- \`scripts.lint:lockfile: pnpm install --frozen-lockfile\`

**\`pnpm-workspace.yaml\`**
- \`minimumReleaseAge: 10080\` → \`20160\` (14d)
- \`minimumReleaseAgeIgnoreMissingTime: true\`
- \`minimumReleaseAgeExclude: ['@pluggyai/*']\`
- \`resolutionMode: highest\`
- \`engineStrict: true\`
- \`trustPolicy: no-downgrade\`
- \`trustPolicyIgnoreAfter: 129600\`
- \`blockExoticSubdeps: true\`
- \`savePrefix: \"\"\`
- \`allowBuilds: {}\` — no postinstall scripts needed (no native deps)
- \`overrides: {}\`

**\`.gitignore\`** — block \`package-lock.json\` and \`yarn.lock\`.

**\`.npmrc\`** removed — \`pnpm-workspace.yaml\` is the single source of truth.

## Verification

- [x] \`pnpm install\` succeeds
- [x] \`pnpm install --frozen-lockfile\` succeeds
- [x] Preinstall hook passes — **0 vulnerabilities**, all signatures verified