### PR TITLE
Add CI for frontend/nextjs (install, lint, test, build)

### DIFF
--- a/.github/workflows/frontend-nextjs-ci.yml
+++ b/.github/workflows/frontend-nextjs-ci.yml
@@ -1,0 +1,62 @@
+name: frontend/nextjs CI
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - frontend/nextjs/**
+      - .github/workflows/frontend-nextjs-ci.yml
+  pull_request:
+    paths:
+      - frontend/nextjs/**
+      - .github/workflows/frontend-nextjs-ci.yml
+
+concurrency:
+  group: frontend-nextjs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: install / lint / test / build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend/nextjs
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.1.1
+          run_install: false
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: frontend/nextjs/pnpm-lock.yaml
+
+      - name: Install dependencies
+        # `preinstall` runs `pnpm audit && pnpm audit signatures`, so a
+        # vulnerable or unsigned package fails the install before any
+        # of the later steps run.
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Test
+        run: pnpm run test
+
+      - name: Build
+        # PLUGGY_* are read at module init in pages/api/token.ts.
+        # Dummy values are enough for `next build` to bundle the
+        # route — runtime calls are not made during build.
+        env:
+          PLUGGY_CLIENT_ID: dummy
+          PLUGGY_CLIENT_SECRET: dummy
+        run: pnpm run build

--- a/frontend/nextjs/package.json
+++ b/frontend/nextjs/package.json
@@ -16,10 +16,12 @@
   "scripts": {
     "preinstall": "pnpm audit && pnpm audit signatures",
     "lint:lockfile": "pnpm install --frozen-lockfile",
+    "typecheck": "tsc --noEmit",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "tsc --noEmit",
+    "test": "tsc --noEmit"
   },
   "dependencies": {
     "next": "15.5.18",


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that validates \`frontend/nextjs\` on every push to master and every PR that touches its files.

## Workflow

\`.github/workflows/frontend-nextjs-ci.yml\` — path-filtered to \`frontend/nextjs/**\` + the workflow file itself. Concurrency-cancels older runs on the same ref.

Steps:
1. \`pnpm install --frozen-lockfile\` — \`preinstall\` runs \`pnpm audit && pnpm audit signatures\`, so a newly disclosed vulnerability or an unsigned package fails CI before any later step.
2. \`pnpm run lint\` → \`tsc --noEmit\`
3. \`pnpm run test\` → \`tsc --noEmit\`
4. \`pnpm run build\` → \`next build\` with dummy \`PLUGGY_CLIENT_ID\` / \`PLUGGY_CLIENT_SECRET\` (read at module init in \`pages/api/token.ts\`; no runtime calls during build).

## Script changes

\`frontend/nextjs/package.json\` adds:
- \`typecheck\` → \`tsc --noEmit\`
- \`test\` → \`tsc --noEmit\` (placeholder until real tests exist)
- \`lint\` replaced from \`next lint\` → \`tsc --noEmit\`

\`next lint\` triggers an interactive ESLint-config wizard when no config exists, and is also deprecated in current Next.js. The quickstart deliberately ships without an ESLint setup, so for CI purposes \`lint\` is the type check. Users wanting real ESLint can add \`eslint-config-next\` on their own fork.

## Verification

- [x] \`pnpm install --frozen-lockfile\` succeeds (preinstall audit + signatures clean)
- [x] \`pnpm run lint\` passes
- [x] \`pnpm run test\` passes
- [x] \`pnpm run build\` succeeds with dummy env vars