### PR TITLE
Add CI for vercel-node-connect-token (install, lint, test, build)

### DIFF
--- a/.github/workflows/vercel-connect-token-ci.yml
+++ b/.github/workflows/vercel-connect-token-ci.yml
@@ -1,0 +1,53 @@
+name: vercel-node-connect-token CI
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - examples/vercel-node-connect-token/**
+      - .github/workflows/vercel-connect-token-ci.yml
+  pull_request:
+    paths:
+      - examples/vercel-node-connect-token/**
+      - .github/workflows/vercel-connect-token-ci.yml
+
+concurrency:
+  group: vercel-connect-token-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: install / lint / test / build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: examples/vercel-node-connect-token
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.1.1
+          run_install: false
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: examples/vercel-node-connect-token/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm run lint
+
+      - name: Test
+        run: pnpm run test
+
+      - name: Build
+        run: pnpm run build

--- a/examples/vercel-node-connect-token/api/token.ts
+++ b/examples/vercel-node-connect-token/api/token.ts
@@ -4,6 +4,11 @@ import { PluggyClient } from 'pluggy-sdk'
 const { PLUGGY_CLIENT_ID, PLUGGY_CLIENT_SECRET } = process.env
 
 export default function (req: VercelRequest, res: VercelResponse) {
+  if (!PLUGGY_CLIENT_ID || !PLUGGY_CLIENT_SECRET) {
+    res.status(500).json({ error: 'Missing PLUGGY_CLIENT_ID or PLUGGY_CLIENT_SECRET' })
+    return
+  }
+
   const pluggyClient = new PluggyClient({
     clientId: PLUGGY_CLIENT_ID,
     clientSecret: PLUGGY_CLIENT_SECRET

--- a/examples/vercel-node-connect-token/package.json
+++ b/examples/vercel-node-connect-token/package.json
@@ -15,12 +15,17 @@
   },
   "scripts": {
     "preinstall": "pnpm audit && pnpm audit signatures",
-    "lint:lockfile": "pnpm install --frozen-lockfile"
+    "lint:lockfile": "pnpm install --frozen-lockfile",
+    "typecheck": "tsc --noEmit",
+    "lint": "tsc --noEmit",
+    "test": "tsc --noEmit",
+    "build": "tsc --noEmit"
   },
   "dependencies": {
     "pluggy-sdk": "0.7.1"
   },
   "devDependencies": {
-    "@vercel/node": "1.10.0"
+    "@vercel/node": "1.10.0",
+    "typescript": "5.9.3"
   }
 }

--- a/examples/vercel-node-connect-token/pnpm-lock.yaml
+++ b/examples/vercel-node-connect-token/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
       '@vercel/node':
         specifier: 1.10.0
         version: 1.10.0
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
 
 packages:
 
@@ -69,6 +72,11 @@ packages:
   typescript@3.9.3:
     resolution: {integrity: sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==}
     engines: {node: '>=4.2.0'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
     hasBin: true
 
   undici-types@7.19.2:
@@ -133,6 +141,8 @@ snapshots:
       yn: 3.1.1
 
   typescript@3.9.3: {}
+
+  typescript@5.9.3: {}
 
   undici-types@7.19.2: {}
 

--- a/examples/vercel-node-connect-token/tsconfig.json
+++ b/examples/vercel-node-connect-token/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "noEmit": true
+  },
+  "include": ["api/**/*"]
+}


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that validates \`examples/vercel-node-connect-token\` on every push to master and every PR touching its files. Same shape as #41 (\`aws-sst\`), #42 (\`frontend/nextjs\`), and #43 (\`vercel-quickdeploy-nextjs\`).

## Workflow

\`.github/workflows/vercel-connect-token-ci.yml\` — path-filtered, concurrency-cancelled. Steps:

1. \`pnpm install --frozen-lockfile\` — \`preinstall\` runs \`pnpm audit && pnpm audit signatures\`.
2. **Lint** → \`pnpm run lint\` (\`tsc --noEmit\`)
3. **Test** → \`pnpm run test\` (\`tsc --noEmit\`)
4. **Build** → \`pnpm run build\` (\`tsc --noEmit\`)

This is a serverless-function project, not a Next.js app — there is no separate framework build step, so all three CI checks are TypeScript compile checks.

## Plumbing changes

\`examples/vercel-node-connect-token/\`:
- new \`tsconfig.json\` (target ES2022, NodeNext, strict, \`isolatedModules\`, \`noEmit\`, includes \`api/**\`)
- \`typescript@5.9.3\` added to \`devDependencies\`
- \`typecheck\`, \`lint\`, \`test\`, \`build\` scripts (all → \`tsc --noEmit\`)

## Source fix surfaced by the type check

\`api/token.ts\` previously passed \`process.env.PLUGGY_CLIENT_ID\` and \`PLUGGY_CLIENT_SECRET\` (each \`string | undefined\`) directly to \`new PluggyClient({...})\`, whose typings require \`string\`. In strict mode this is a type error, and at runtime it would have silently constructed a client with \`undefined\` credentials.

Now the handler guards both env vars and returns a 500 with a clear message when either is missing.

## Verification

- [x] \`pnpm install --frozen-lockfile\` succeeds (preinstall audit + signatures clean)
- [x] \`pnpm run lint\` / \`pnpm run test\` / \`pnpm run build\` all pass