### PR TITLE
Wire frontend/react-native-expo for pnpm 11 (config only; lockfile follow-up)

### DIFF
--- a/frontend/react-native-expo/.gitignore
+++ b/frontend/react-native-expo/.gitignore
@@ -3,6 +3,10 @@
 # dependencies
 node_modules/
 
+# Block npm/yarn lockfiles — this project is pnpm-only
+package-lock.json
+yarn.lock
+
 # Expo
 .expo/
 dist/

--- a/frontend/react-native-expo/package.json
+++ b/frontend/react-native-expo/package.json
@@ -2,13 +2,30 @@
   "name": "pluggy",
   "main": "expo-router/entry",
   "version": "1.0.0",
+  "packageManager": "pnpm@11.1.1",
+  "engines": {
+    "node": ">=24.0.0",
+    "pnpm": ">=11.0.0"
+  },
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": ">=24.0.0",
+      "onFail": "error"
+    }
+  },
   "scripts": {
+    "preinstall": "pnpm audit && pnpm audit signatures",
+    "lint:lockfile": "pnpm install --frozen-lockfile",
+    "typecheck": "tsc --noEmit",
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "lint": "expo lint"
+    "lint": "tsc --noEmit",
+    "test": "tsc --noEmit",
+    "build": "tsc --noEmit"
   },
   "dependencies": {
     "@expo/vector-icons": "15.0.3",

--- a/frontend/react-native-expo/pnpm-workspace.yaml
+++ b/frontend/react-native-expo/pnpm-workspace.yaml
@@ -1,0 +1,56 @@
+# Supply-chain hardening
+# ----------------------
+
+# Reject any package version published less than 14 days ago when
+# resolving. Most supply-chain attacks are detected within hours or
+# days; the 14-day window absorbs that while keeping upgrades moving
+# at a reasonable pace. For a critical CVE that demands a sub-14d
+# upgrade, add a temporary `minimumReleaseAgeExclude` entry with a
+# CVE link and remove it once the window closes.
+# 14 days = 60 * 24 * 14 minutes
+minimumReleaseAge: 20160
+
+# When the registry metadata is missing the `time` field for a
+# version, fall back to allowing it.
+minimumReleaseAgeIgnoreMissingTime: true
+
+# Whitelist for the 14-day wait. `@pluggyai/*` ships from our own
+# release pipeline.
+minimumReleaseAgeExclude:
+  - '@pluggyai/*'
+
+# Pinned explicitly to survive any future default change.
+resolutionMode: highest
+
+# Refuse to install if Node / pnpm don't satisfy the `engines` field.
+engineStrict: true
+
+# Fail the install if a package version's trust level drops
+# compared to earlier versions.
+trustPolicy: no-downgrade
+
+# Auto-skip the trust check for packages older than 90 days.
+trustPolicyIgnoreAfter: 129600
+
+# Block transitive deps from being resolved from exotic sources.
+blockExoticSubdeps: true
+
+
+# Version pinning
+# ---------------
+
+# Save exact resolved versions (no semver ranges) on `pnpm add`.
+savePrefix: ""
+
+
+# Per-package decisions
+# ---------------------
+
+# pnpm 11 blocks postinstall / install / preinstall scripts by
+# default; every package that ships one must be listed here.
+# Default-deny: new entries start as `false` and only flip to `true`
+# after a conscious review.
+allowBuilds: {}
+
+# Force a specific version on transitive dependencies.
+overrides: {}


### PR DESCRIPTION
## Summary

**Draft.** Config-only bump for \`frontend/react-native-expo\`. This PR sets up the pnpm 11 metadata + supply-chain hardening but does **not** run \`pnpm install\` — the \`pnpm-lock.yaml\` and the removal of the old \`package-lock.json\` / \`.npmrc\` need to happen on a machine that can actually install (Expo pulls native deps that may need their own postinstall decisions).

## What's in this PR

**\`package.json\`**
- \`packageManager: pnpm@11.1.1\`
- \`engines: { node: >=24.0.0, pnpm: >=11.0.0 }\`
- \`devEngines.runtime\` with \`onFail: error\`
- \`scripts.preinstall: pnpm audit && pnpm audit signatures\`
- \`scripts.lint:lockfile: pnpm install --frozen-lockfile\`
- \`scripts.typecheck / lint / test / build\` → \`tsc --noEmit\` (was \`expo lint\`, which errors out interactively without an eslint config; typecheck is the safe baseline for now)

**\`pnpm-workspace.yaml\`** — full supply-chain stack:
- \`minimumReleaseAge: 20160\` (14d)
- \`minimumReleaseAgeIgnoreMissingTime: true\`
- \`minimumReleaseAgeExclude: ['@pluggyai/*']\`
- \`engineStrict: true\`
- \`trustPolicy: no-downgrade\`, \`trustPolicyIgnoreAfter: 129600\` (90d)
- \`blockExoticSubdeps: true\`
- \`savePrefix: ""\`
- \`resolutionMode: highest\`
- \`allowBuilds: {}\` — to be populated on first \`pnpm install\` (Expo ships native deps like \`react-native-reanimated\` with postinstall scripts; each one needs an explicit yes/no decision)
- \`overrides: {}\`

**\`.gitignore\`** — adds \`package-lock.json\` and \`yarn.lock\`.

## Follow-up required before merging

1. Run \`pnpm install\` to generate \`pnpm-lock.yaml\`.
2. Delete the now-stale \`.npmrc\` and \`package-lock.json\`.
3. Populate \`allowBuilds\` in \`pnpm-workspace.yaml\` with conscious yes/no decisions for each native dep that asks for a postinstall (default-deny per repo policy).
4. Re-run audit; resolve anything that surfaces with \`overrides\` / \`minimumReleaseAgeExclude\` entries as in #38–#45.
5. Add \`.github/workflows/expo-ci.yml\` matching the other per-project workflows.