### PR TITLE
Set @pluggyai/public-codeowners as the single repo CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,7 @@
 ## Code changes in submitted PRs will include the following
-## team/users as default reviewers.
-## For this to be valid, these users have to have Write access to the repo.
+## team as the default reviewer.
+## For this to be valid, the team has to have Write access to the repo.
 ##
 ## docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-##
 
-* @pluggyai/ramen @pluggyai/tech-leaders
+* @pluggyai/public-codeowners


### PR DESCRIPTION
## Summary

Sets \`@pluggyai/public-codeowners\` as the single \`CODEOWNERS\` entry for the whole repo.

```
* @pluggyai/public-codeowners
```

No path-specific rules — this is a quickstart repo, granular ownership over \`.github/\` or specific files would add noise without adding value.

Same one-line template applied across `pluggyai/quickstart`, `pluggyai/pluggy-java`, `pluggyai/pluggy-node`, `pluggyai/pluggy-net`.